### PR TITLE
修复systemCmd进程退出回调的错误

### DIFF
--- a/BDSJSR2/Program.cs
+++ b/BDSJSR2/Program.cs
@@ -267,7 +267,6 @@ namespace BDSJSR2
                                   exitTime = cli.ExitTime,
                                   exitCode = cli.ExitCode,
                                   msElapsed = Math.Round((cli.ExitTime - cli.StartTime).TotalMilliseconds),
-                                  HandleCount = cli.HandleCount,
                                   Id = cli.Id
                               }));
                           }


### PR DESCRIPTION
修复systemCmd进程退出回调的错误
HandleCount = cli.HandleCount 因为进程退出，无法获取，已删除